### PR TITLE
bugfix: return false when the route is undefined

### DIFF
--- a/lib/activeroute.coffee
+++ b/lib/activeroute.coffee
@@ -25,6 +25,8 @@ share.config.set
   disabledClass: 'disabled'
 
 test = (value, pattern) ->
+  return false if !value
+
   if Match.test pattern, RegExp
     result = value.search pattern
     result = result > -1


### PR DESCRIPTION
When the current route is undefined, we return false for ActiveRoute.name.

The current route may be undefined because the router is not ready yet.