### PR TITLE
Regex option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2.0.5-rc.1] - 2015-06-08
 
-  * Add regex option which makes template helpers support regex
-    in the {{isActiveRoute '^home'}} syntax
+  * Add `regex` option which makes template helpers support regex
+    using the {{isActiveRoute '^home'}} syntax
 
 ## [2.0.4] - 2015-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [2.0.5-rc.1] - 2015-06-08
+## [2.1.0] - 2015-06-08
 
   * Add `regex` option which makes template helpers support regex
     using the {{isActiveRoute '^home'}} syntax
@@ -91,7 +91,7 @@
 
   * See [git history]
 
-[2.0.5-rc.1]: https://github.com/zimme/meteor-active-route/compare/2.0.4...2.0.5-rc.1
+[2.1.0]: https://github.com/zimme/meteor-active-route/compare/2.0.4...2.1.0
 [2.0.4]: https://github.com/zimme/meteor-active-route/compare/2.0.3...2.0.4
 [2.0.3]: https://github.com/zimme/meteor-active-route/compare/2.0.2...2.0.3
 [2.0.2]: https://github.com/zimme/meteor-active-route/compare/2.0.1...2.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.5-rc.1] - 2015-06-08
+
+  * Add regex option which makes template helpers support regex
+    in the {{isActiveRoute '^home'}} syntax.
+
 ## [2.0.4] - 2015-06-06
 
   * Add tests for global configuration
@@ -86,6 +91,7 @@
 
   * See [git history]
 
+[2.0.5-rc.1]: https://github.com/zimme/meteor-active-route/compare/2.0.4...2.0.5-rc.1
 [2.0.4]: https://github.com/zimme/meteor-active-route/compare/2.0.3...2.0.4
 [2.0.3]: https://github.com/zimme/meteor-active-route/compare/2.0.2...2.0.3
 [2.0.2]: https://github.com/zimme/meteor-active-route/compare/2.0.1...2.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2.0.5-rc.1] - 2015-06-08
 
   * Add regex option which makes template helpers support regex
-    in the {{isActiveRoute '^home'}} syntax.
+    in the {{isActiveRoute '^home'}} syntax
 
 ## [2.0.4] - 2015-06-06
 

--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ Returns either a configurable `string`, which defaults to `'disabled'`, or
 
 The following can be used by the template helpers as arguments.
 
-* Data context, Optional. `'string'`.
+* Data context, Optional. `'string'`
 * `name`, Optional. `'string'`. Only available for `isActiveRoute` and
   `isNotActiveRoute`
 * `path`, Optional. `'string'`. Only available for `isActivePath` and
-  `isNotActivePath`.
-* `regex`, Optional. `'string'` or `RegExp`.
+  `isNotActivePath`
+* `regex`, Optional. `'string'` or `RegExp`
 
 At least one of Data context, `route` or `path` need to be supplied.
 
@@ -187,10 +187,10 @@ The javascript helpers accepts `'string'` or `RegExp` as an argument.
 ## Global options
 
 * `activeClass`, Optional. Set to `'string'` to change the default
-  `class` for `isActiveRoute` and `isActivePath`.
-* `caseSensitive`, Optional. Set to `false` to make matching case-insensitive.
+  `class` for `isActiveRoute` and `isActivePath`
+* `caseSensitive`, Optional. Set to `false` to make matching case-insensitive
 * `disabledClass`, Optional. Set to `'string'` to change the default
-  `class` for `isNotActiveRoute` and `isNotActivePath`.
+  `class` for `isNotActiveRoute` and `isNotActivePath`
 
 ```js
 // Configure helpers globally
@@ -206,9 +206,9 @@ ActiveRoute.configure({
 
 * This version SHOULD be backwards-compatible with
   `zimme:iron-router-active@1.0.4`
-* `ActiveRoute.config` is an alias for `ActiveRoute.configure`.
-* `className` is an alias for `class` in the template helpers.
-* This package supports javascript's `RegExp`, [here][Regexp]'s some good info.
+* `ActiveRoute.config` is an alias for `ActiveRoute.configure`
+* `className` is an alias for `class` in the template helpers
+* This package supports javascript's `RegExp`, [here][Regexp]'s some good info
 
 [Code Climate]: https://img.shields.io/codeclimate/github/zimme/meteor-active-route.svg
 [Gitter]: https://img.shields.io/badge/gitter-join_chat-brightgreen.svg

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ The javascript helpers accepts `'string'` or `RegExp` as an argument.
 * `caseSensitive`, Optional. Set to `false` to make matching case-insensitive
 * `disabledClass`, Optional. Set to `'string'` to change the default
   `class` for `isNotActiveRoute` and `isNotActivePath`
+* `regex`, Optional. Set to `true` to make tempalte helpers use regex matching
+  with the following syntax, `{{isActiveRoute '^home'}}`
 
 ```js
 // Configure helpers globally
@@ -198,7 +200,8 @@ The javascript helpers accepts `'string'` or `RegExp` as an argument.
 ActiveRoute.configure({
   activeClass: 'active',
   caseSensitive: true,
-  disabledClass: 'disabled'
+  disabledClass: 'disabled',
+  regex: 'false'
 });
 ```
 

--- a/client/helpers.coffee
+++ b/client/helpers.coffee
@@ -10,7 +10,11 @@ isActive = (type, inverse = false) ->
 
   (view = {hash: {}}) ->
     if Match.test view, String
-      if type is 'Path'
+      if share.config.equals 'regex', true
+        hash =
+          regex: view
+
+      else if type is 'Path'
         hash =
           path: view
 

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   git: 'https://github.com/zimme/meteor-active-route.git',
   name: 'zimme:active-route',
   summary: 'Active route helpers',
-  version: '2.0.4_1'
+  version: '2.0.5-rc.1'
 });
 
 Package.onUse(function(api) {

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   git: 'https://github.com/zimme/meteor-active-route.git',
   name: 'zimme:active-route',
   summary: 'Active route helpers',
-  version: '2.0.5-rc.1'
+  version: '2.1.0'
 });
 
 Package.onUse(function(api) {

--- a/tests/lib/activeroute.coffee
+++ b/tests/lib/activeroute.coffee
@@ -35,6 +35,22 @@ makeClientTests = ->
       activeClass: 'active'
       disabledClass: 'disabled'
 
+  it 'ActiveRoute.config({caseSensitive: false, regex: true})', ->
+    expect ActiveRoute.config
+      caseSensitive: false
+      regex: true
+    .to.be.undefined
+
+    expect Blaze._globalHelpers['isActiveRoute'] '^hoMe$'
+      .to.be.a.string 'active'
+
+    expect Blaze._globalHelpers['isActivePath'] '^\/$'
+      .to.be.a.string 'active'
+
+    ActiveRoute.config
+      caseSensitive: true
+      regex: false
+
   it 'ActiveRoute.config({regex: true})', ->
     expect ActiveRoute.config
       regex: true

--- a/tests/lib/activeroute.coffee
+++ b/tests/lib/activeroute.coffee
@@ -35,6 +35,20 @@ makeClientTests = ->
       activeClass: 'active'
       disabledClass: 'disabled'
 
+  it 'ActiveRoute.config({regex: true})', ->
+    expect ActiveRoute.config
+      regex: true
+    .to.be.undefined
+
+    expect Blaze._globalHelpers['isActiveRoute'] '^home$'
+      .to.be.a.string 'active'
+
+    expect Blaze._globalHelpers['isActivePath'] '^\/$'
+      .to.be.a.string 'active'
+
+    ActiveRoute.config
+      regex: false
+
   it 'ActiveRoute.name(\'home\')', ->
     expect ActiveRoute.name 'home'
       .to.be.true


### PR DESCRIPTION
This PR is to add an option for supporting regex matching with the syntax `{{isActiveRoute '^home'}}` which by default only do string matching, because of performance and that the "normal" user don't need regex matching by default.